### PR TITLE
Don't show subfolders as items in the gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,7 +343,7 @@
         sissy.urls = [];
 
         gapi.client.drive.files.list({
-          'q': "trashed=false and '" + folderId + "' in parents",
+          'q': "trashed=false and '" + folderId + "' in parents and mimeType != 'application/vnd.google-apps.folder' and mimeType != 'application/vnd.google-apps.drive-sdk'",
           'fields': "files(id, name)",
           'pageSize': 1000
         }).then(function(response){


### PR DESCRIPTION
I noticed when my conditioning folder had some subfolders in it with images that didn't make the cut, that the conditioning app would count the folders (but not their contents) as pictures to show.

The slideshow would also pause at these subfolders, but would instead just show an icon like 🚫(Forbidden/Prohibited). This is because the URL for the folders would result in a 404 error.

This PR makes the filter in listFiles skip folders and shortcuts by filtering them out based on their mimeType (https://developers.google.com/drive/v3/web/about-files).